### PR TITLE
cmake: google test from main branch

### DIFF
--- a/googletest-CMakeLists.txt.in
+++ b/googletest-CMakeLists.txt.in
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
When attempting to build, cmake will fail for want of googletest.  Looks like it needs the main branch, not master.